### PR TITLE
Create openapi.yaml

### DIFF
--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -142,7 +142,7 @@ paths:
     get:
       operationId: GetGewijzigdePersonen
       description: |
-        Opvragen lijst met gewijzigdepersonen op relevante burgerservicenummers.
+        Opvragen lijst met burgerservicenummers van personen waarop in de gegevens een wijziging is aangebracht.
       parameters:
         - in: query
           name: vanaf
@@ -197,42 +197,24 @@ components:
       type: object
       properties:
         _links:
-          $ref: "#/components/schemas/VolgindicatiePersonenHalCollectionLinks"
-        burgerservicenummers:
-          type: array
-          items:
-            $ref: '#/components/schemas/VolgindicatiePersonenHal'
-    VolgindicatiePersonenHalCollectionLinks:
-      type: object
-      properties:
-        self:
-          $ref: "#/components/schemas/VolgindicatiePersonenHalLink"
-    VolgindicatiePersonenHal:
-      allOf:
-        - $ref: '#/components/schemas/Burgerservicenummer'
-    VolgindicatiePersonenHalLink:
-      description: De Link Object zoals gespecificeerd in https://tools.ietf.org/html/draft-kelly-json-hal-08#section-5
-      type: object
-      required:
-        - href
-      properties:
-        href:
-          $ref: "#/components/schemas/VolgindicatiePersonenHref"
-        title:
-         description: "Voor mens leesbaar label bij de link"
-         type: string
-    VolgindicatiePersonenHref:
-      type: string
-      example: "https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/volgindicatiepersonen"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalCollectionLinks"
+        _embedded:
+          $ref: '#/components/schemas/VolgindicatiePersonen'
     VolgindicatiePersonen:
-      required:
-        - burgerservicenummers
       type: object
       properties:
-        burgerservicenummers:
+        volgindicatiepersonen:
           type: array
           items:
-            $ref: '#/components/schemas/Burgerservicenummer'
+            $ref: '#/components/schemas/VolgindicatiePersoon'
+    VolgindicatiePersoon:
+      type: object
+      properties:
+        burgerservicenummer:
+          $ref: '#/components/schemas/Burgerservicenummer'
+        einddatum:
+          type: "string"
+          format: "date"
     GewijzigdepersonenHalCollectie:
       type: object
       properties:
@@ -241,42 +223,14 @@ components:
         burgerservicenummers:
           type: array
           items:
-            $ref: '#/components/schemas/GewijzigdepersonenHal'
+            $ref: '#/components/schemas/Burgerservicenummer'
     GewijzigdepersonenHalCollectionLinks:
       type: object
       properties:
         self:
-          $ref: "#/components/schemas/GewijzigdepersonenHalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         ingeschrevenPersoon:
-          $ref: "#/components/schemas/Gewijzigdepersoon_Link"
-    GewijzigdepersonenHal:
-      allOf:
-        - $ref: '#/components/schemas/Burgerservicenummer'
-    GewijzigdepersonenHalLink:
-      description: De Link Object zoals gespecificeerd in https://tools.ietf.org/html/draft-kelly-json-hal-08#section-5
-      type: object
-      required:
-        - href
-      properties:
-        href:
-          $ref: "#/components/schemas/GewijzigdepersonenHref"
-        title:
-         description: "Voor mens leesbaar label bij de link"
-         type: string
-    Gewijzigdepersoon_Link:
-      type: object
-      properties:
-        href:
-          type: string
-          example: "https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/ingeschrevenpersonen/{burgerservicenummer}"
-        templated:
-          type: boolean
-        title:
-         description: "Voor mens leesbaar label bij de link"
-         type: string
-    GewijzigdepersonenHref:
-      type: string
-      example: "https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/gewijzigdepersonen"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
     Burgerservicenummer:
       type: "string"
       title: "Burgerservicenummer"

--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -1,0 +1,291 @@
+openapi: 3.0.0
+info:
+  title: "BRP Update API"
+  version: "1.0.0"
+  description: |
+        Het instellen van volgindicaties op ingeschrevenpersonen, het beëindigen van die volgindicaties, het opvragen van alle van voor een abonnee ingestelde volgindicaties en het opvragen van de aanwezigheid van wijzigingen op ingeschrevenpersonen.
+paths:
+  /volgindicatiepersonen:
+    post:
+      operationId: PostVolgindicatiePersonen
+      description: |
+        Instellen volgindicatie op burgerservicenummer voor een abonnee.
+      parameters:
+        - in: query
+          name: einddatum
+          required: false
+          explode: false
+          schema:
+            type: "string"
+            format: "date"
+      requestBody:
+        content:
+          application/json:
+            schema:
+                $ref: '#/components/schemas/VolgindicatiePersonen'
+      responses:
+        '201':
+          description: "OK"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VolgindicatiePersonen'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/403"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/default"
+      tags:
+      - volgindicatiepersonen
+    get:
+      operationId: GetVolgindicatiePersonen
+      description: |
+        Opvragen lijst met burgerservicenummers waarop een abonnee een volgindicatie heeft ingesteld.
+      responses:
+        200:
+          description: "OK"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: "#/components/schemas/VolgindicatiePersonenHalCollectie"
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/403"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/406"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/500"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/503"
+      tags:
+      - volgindicatiepersonen
+  /volgindicatiepersonen/{burgerservicenummer}:
+    delete:
+      operationId: DeleteVolgindicatiePersonen
+      description: |
+        Beëindigen volgindicatie op burgerservicenummer voor een abonnee.
+      parameters:
+        - in: path
+          name: burgerservicenummer
+          required: true
+          description: "Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet\
+            \ algemene bepalingen burgerservicenummer. Alle nummers waarvoor geldt\
+            \ dat, indien aangeduid als (s0 s1 s2 s3 s4 s5 s6 s7 s8), het resultaat\
+            \ van (9*s0) + (8*s1) + (7*s2) +...+ (2*s7) - (1*s8) deelbaar is door\
+            \ elf. Er moeten dus 9 cijfers aanwezig zijn."
+          explode: false
+          schema:
+            $ref: "#/components/schemas/Burgerservicenummer"
+      responses:
+        200:
+          description: "OK"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VolgindicatiePersonen"
+        '204':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/204"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/404"
+      tags:
+      - volgindicatiepersonen
+  /gewijzigdepersonen:
+    get:
+      operationId: GetGewijzigdePersonen
+      description: |
+        Opvragen lijst met gewijzigdepersonen op relevante burgerservicenummers.
+      parameters:
+        - in: query
+          name: vanaf
+          required: false
+          explode: false
+          schema:
+            type: "string"
+            format: "date"
+      responses:
+        200:
+          description: "OK"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                $ref: "#/components/schemas/GewijzigdepersonenHalCollectie"
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/403"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/406"
+        '409':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/409"
+        '410':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/410"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/415"
+        '429':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/429"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/500"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/503"
+      tags:
+      - gewijzigdepersonen
+components:
+  schemas:
+    VolgindicatiePersonenHalCollectie:
+      type: object
+      properties:
+        _links:
+          $ref: "#/components/schemas/VolgindicatiePersonenHalCollectionLinks"
+        burgerservicenummers:
+          type: array
+          items:
+            $ref: '#/components/schemas/VolgindicatiePersonenHal'
+    VolgindicatiePersonenHalCollectionLinks:
+      type: object
+      properties:
+        self:
+          $ref: "#/components/schemas/VolgindicatiePersonenHalLink"
+    VolgindicatiePersonenHal:
+      allOf:
+        - $ref: '#/components/schemas/Burgerservicenummer'
+    VolgindicatiePersonenHalLink:
+      description: De Link Object zoals gespecificeerd in https://tools.ietf.org/html/draft-kelly-json-hal-08#section-5
+      type: object
+      required:
+        - href
+      properties:
+        href:
+          $ref: "#/components/schemas/VolgindicatiePersonenHref"
+        title:
+         description: "Voor mens leesbaar label bij de link"
+         type: string
+    VolgindicatiePersonenHref:
+      type: string
+      example: "https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/volgindicatiepersonen"
+    VolgindicatiePersonen:
+      required:
+        - burgerservicenummers
+      type: object
+      properties:
+        burgerservicenummers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Burgerservicenummer'
+    GewijzigdepersonenHalCollectie:
+      type: object
+      properties:
+        _links:
+          $ref: "#/components/schemas/GewijzigdepersonenHalCollectionLinks"
+        burgerservicenummers:
+          type: array
+          items:
+            $ref: '#/components/schemas/GewijzigdepersonenHal'
+    GewijzigdepersonenHalCollectionLinks:
+      type: object
+      properties:
+        self:
+          $ref: "#/components/schemas/GewijzigdepersonenHalLink"
+        ingeschrevenPersoon:
+          $ref: "#/components/schemas/Gewijzigdepersoon_Link"
+    GewijzigdepersonenHal:
+      allOf:
+        - $ref: '#/components/schemas/Burgerservicenummer'
+    GewijzigdepersonenHalLink:
+      description: De Link Object zoals gespecificeerd in https://tools.ietf.org/html/draft-kelly-json-hal-08#section-5
+      type: object
+      required:
+        - href
+      properties:
+        href:
+          $ref: "#/components/schemas/GewijzigdepersonenHref"
+        title:
+         description: "Voor mens leesbaar label bij de link"
+         type: string
+    Gewijzigdepersoon_Link:
+      type: object
+      properties:
+        href:
+          type: string
+          example: "https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/ingeschrevenpersonen/{burgerservicenummer}"
+        templated:
+          type: boolean
+        title:
+         description: "Voor mens leesbaar label bij de link"
+         type: string
+    GewijzigdepersonenHref:
+      type: string
+      example: "https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/gewijzigdepersonen"
+    Burgerservicenummer:
+      type: "string"
+      title: "Burgerservicenummer"
+      description: "Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet\
+        \ algemene bepalingen burgerservicenummer. Alle nummers waarvoor geldt\
+        \ dat, indien aangeduid als (s0 s1 s2 s3 s4 s5 s6 s7 s8), het resultaat\
+        \ van (9*s0) + (8*s1) + (7*s2) +...+ (2*s7) - (1*s8) deelbaar is door\
+        \ elf. Er moeten dus 9 cijfers aanwezig zijn."
+      pattern: "^[0-9]*$"
+      maxLength: 9
+      minLength: 9
+      example: "555555021"

--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -10,14 +10,6 @@ paths:
       operationId: PostVolgindicatiePersonen
       description: |
         Instellen volgindicatie op burgerservicenummer voor een abonnee.
-      parameters:
-        - in: query
-          name: einddatum
-          required: false
-          explode: false
-          schema:
-            type: "string"
-            format: "date"
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Bij het vervaardigen van deze specificatie kwamen de volgende vragen boven drijven:

* Het bericht 'post /volgindicatiepersonen' heb ik van de parameter 'einddatum' voorzien omdat we in staat willen zijn een 'einddatum' van de volgindicatie aan te kunnen geven (zie #1) De vraag is of dit een parameter moet zijn aangezien dat betekent dat:
  - alle bsn's in de post dezelfde einddatum zullen hebben;
  - de einddatum naderhand niet meer op te vragen is.
* indien we er voor kiezen om 'einddatum' niet als parameter mee te geven willen we die dan per bsn op kunnen geven wat betekent dat de huidige constructie van burgerservicenummers 

	{
	  "burgerservicenummers": [
	    "555555021, 555555022"
	  ]
	}

   volgens mij niet voldoet.
* In de berichten 'get /volgindicatiepersonen' en 'get /gewijzigdepersonen' is geen _embedded aanwezig. 'burgerservicenummer' is immers geen object. Is dat conform verwachtingen?
* In de berichten 'get /volgindicatiepersonen' en 'get /gewijzigdepersonen' bevat de 'self' link geen templated url. Is dat conform verwachtingen?
* In het bericht 'get /gewijzigdepersonen' heeft de 2e variabele in de templated url de waarde 'burgerservicenummer' terwijl in het bericht het veld 'burgerservicenummers' staat en deze een array kan bevatten. Is de templated url wel in de juiste vorm?