### PR TITLE
herinrichting van de API specificaties

### DIFF
--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -169,7 +169,7 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/default"
       tags:
       - Beheren volgindicaties
-  /gewijzigdepersonen:
+  /wijzigingen:
     get:
       operationId: GetGewijzigdePersonen
       description: |
@@ -210,7 +210,7 @@ paths:
         'default':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/default"
       tags:
-      - Gewijzigde personen
+      - Raadplegen gewijzigde personen
 components:
   parameters:
     burgerservicenummer:

--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -173,6 +173,7 @@ paths:
       operationId: GetGewijzigdePersonen
       description: |
         Opvragen lijst met burgerservicenummers van personen waarop in de gegevens een wijziging is aangebracht.
+      summary: "Raadplegen personen met gewijzigde gegevens"
       parameters:
         - in: query
           name: vanaf

--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -50,7 +50,7 @@ paths:
       operationId: GetVolgindicatie
       description: |
         Opvragen van een volgindicatie van een specifieke persoon.
-      summary: "Raadpleeg specifieke volgindicatie"
+      summary: "Raadplegen specifieke volgindicatie"
       parameters:
         - $ref: '#/components/parameters/burgerservicenummer'
       responses:
@@ -217,8 +217,7 @@ components:
       in: path
       name: burgerservicenummer
       required: true
-      description: "Identificerend gegeven van een ingeschreven natuurlijk persoon, als bedoeld in artikel 1.1 van de Wet\
-        \ algemene bepalingen burgerservicenummer."
+      description: "Identificerend gegeven van een ingeschreven natuurlijk persoon, als bedoeld in artikel 1.1 van de Wet algemene bepalingen burgerservicenummer."
       schema:
         pattern: "^[0-9]*$"
         maxLength: 9
@@ -251,14 +250,22 @@ components:
       properties:
         self:
           $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/schemas/HalLink'
-    VolgindicatieHal:
+    VolgindicatieRaadplegen:
       allOf:
         - $ref: '#/components/schemas/Volgindicatie'
+        - properties:
+            burgerservicenummer:
+              type: string
+              description: "Identificerend gegeven van een ingeschreven natuurlijk persoon, als bedoeld in artikel 1.1 van de Wet algemene bepalingen burgerservicenummer."
+    VolgindicatieHal:
+      allOf:
+        - $ref: '#/components/schemas/VolgindicatieRaadplegen'
         - properties:
             _links:
               $ref: '#/components/schemas/Volgindicatie_links'
           example:
             einddatum: '2022-10-24'
+            burgerservicenummer: '555555021'
             _links:
               self:
                 href: '/volgindicaties/555555021'

--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -1,12 +1,12 @@
 openapi: 3.0.0
 servers:
+# Added by API Auto Mocking Plugin
   - description: "SwaggerHub API Auto Mocking"
     url: https://virtserver.swaggerhub.com/VNGRealisatie/api/brp_update_api
 info:
   title: "BRP Update API"
-  description: |
-        Het instellen van volgindicaties op ingeschrevenpersonen, het beëindigen van die volgindicaties, het opvragen van alle van voor een abonnee ingestelde volgindicaties en het opvragen van de aanwezigheid van wijzigingen op ingeschrevenpersonen.
-        Een volgindicatie kan worden beëindigd door het opgeven van een deleteDatum.
+  description: "Deze API biedt functionaliteit voor het opvragen van  wijzigingen op ingeschreven personen die door de gebruiker worden gevolgd vanaf een bepaald moment. Dit kan gebruikt worden om een kopie aan te leggen van de actuele registratie van specifieke personen.<br/>
+        De API biedt functionaliteit waarmee kan worden aangegeven welke personen worden gevolgd."
   version: "1.0.0"
   contact:
     url: https://github.com/JohanBoer/Haal-Centraal-BRP-Update-API
@@ -14,19 +14,14 @@ info:
     name: European Union Public License, version 1.2 (EUPL-1.2)
     url: https://eupl.eu/1.2/nl/
 paths:
-  /volgindicatiepersonen:
-    post:
-      operationId: PostVolgindicatiePersonen
-      summary: "instellen volgindicatie"
+  /volgindicaties:
+    get:
+      operationId: GetVolgindicaties
+      summary: "Raadplegen alle actieve volgindicaties"
       description: |
-        Instellen volgindicatie op burgerservicenummer voor een abonnee. Door het opnemen van deleteDatum kan worden aangegeven dat de volgindicatie op een bepaalde datum automatisch moet worden verwijderd.
-      requestBody:
-        content:
-          application/json:
-            schema:
-                $ref: '#/components/schemas/VolgindicatiePersoon'
+        Opvragen van alle actuele (actieve) volgindicaties van een abonnee. Volgindicaties met een einddatum in het verleden worden niet geleverd.
       responses:
-        '201':
+        200:
           description: "OK"
           headers:
             api-version:
@@ -34,19 +29,15 @@ paths:
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/warning"
           content:
-            application/json:
+            application/hal+json:
               schema:
-                $ref: '#/components/schemas/VolgindicatiePersoon'
-        '400':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/400"
+                $ref: "#/components/schemas/VolgindicatiesHalCollectie"
         '401':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/401"
         '403':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/403"
-        '419':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/409"
-        '415':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/415"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/406"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/500"
         '503':
@@ -54,58 +45,15 @@ paths:
         'default':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/default"
       tags:
-      - volgindicatiepersonen
+      - Beheren volgindicaties
+  /volgindicaties/{burgerservicenummer}:
     get:
-      operationId: GetVolgindicatiePersonen
-      summary: "raadplegen alle volgindicaties"
+      operationId: GetVolgindicatie
       description: |
-        Opvragen lijst met burgerservicenummers waarop een abonnee een actuele volgindicatie heeft ingesteld.
-      responses:
-        200:
-          description: "OK"
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: "#/components/schemas/VolgindicatiePersonenHalCollectie"
-        '400':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/400"
-        '401':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/401"
-        '403':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/403"
-        '406':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/406"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/410"
-        '500':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/500"
-        'default':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/default"
-      tags:
-      - volgindicatiepersonen
-  /volgindicatiepersonen/{burgerservicenummer}:
-    get:
-      operationId: GetVolgindicatiePersoon
-      description: |
-        Opvragen specifiek abonnenement op een burgerservicenummer waarop een abonnee een volgindicatie heeft ingesteld.
-      summary: "raadpleeg specifieke volgindicatie"
+        Opvragen van een volgindicatie van een specifieke persoon.
+      summary: "Raadpleeg specifieke volgindicatie"
       parameters:
-        - in: path
-          name: burgerservicenummer
-          required: true
-          description: "Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet\
-            \ algemene bepalingen burgerservicenummer. Alle nummers waarvoor geldt\
-            \ dat, indien aangeduid als (s0 s1 s2 s3 s4 s5 s6 s7 s8), het resultaat\
-            \ van (9*s0) + (8*s1) + (7*s2) +...+ (2*s7) - (1*s8) deelbaar is door\
-            \ elf. Er moeten dus 9 cijfers aanwezig zijn."
-          explode: false
-          schema:
-            $ref: "#/components/schemas/Burgerservicenummer"
+        - $ref: '#/components/parameters/burgerservicenummer'
       responses:
         200:
           description: "OK"
@@ -117,7 +65,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: "#/components/schemas/VolgindicatiePersoon"
+                $ref: "#/components/schemas/VolgindicatieHal"
         '400':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/400"
         '401':
@@ -130,10 +78,97 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/406"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/500"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/503"
         'default':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/default"
       tags:
-      - volgindicatiepersonen
+      - Beheren volgindicaties
+    put:
+      operationId: UpsertVolgindicatie
+      description: |
+        Toevoegen of wijzigen van een volgindicatie van een specifieke persoon. Wanneer er nog geen volgindicatie is op deze persoon wordt de volgindicatie toegevoegd. Wanneer er al een volgindicatie is op deze persoon, wordt de volgindicatie gewijzigd.
+        De einddatum op een volgindicatie kan worden verwijderd (leeg gemaakt) door een leeg object { } te sturen in de request body.
+      summary: "Toevoegen of wijzigen volgindicatie"
+      parameters:
+        - $ref: '#/components/parameters/burgerservicenummer'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Volgindicatie'
+      responses:
+        '200':
+          description: "Volgindicatie gewijzigd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: "#/components/schemas/VolgindicatieHal"
+        '201':
+          description: "Volgindicatie toegevoegd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/VolgindicatieHal'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/403"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/406"
+        '415':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/415"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/500"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/default"
+      tags:
+      - Beheren volgindicaties
+    delete:
+      operationId: DeleteVolgindicatie
+      description: |
+        Verwijderen van een volgindicatie van een specifieke persoon.
+      summary: "Toevoegen of wijzigen volgindicatie"
+      parameters:
+        - $ref: '#/components/parameters/burgerservicenummer'
+      responses:
+        '204':
+          description: "Volgindicatie verwijderd"
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/headers/warning"
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/403"
+        '404':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/404"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/500"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/default"
+      tags:
+      - Beheren volgindicaties
   /gewijzigdepersonen:
     get:
       operationId: GetGewijzigdePersonen
@@ -144,6 +179,7 @@ paths:
           name: vanaf
           required: false
           explode: false
+          description: Alleen personen waarbij gegevens zijn gewijzigd op of na deze datum worden geleverd.
           schema:
             type: "string"
             format: "date"
@@ -167,37 +203,65 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/403"
         '406':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/406"
-        '409':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/409"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/410"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/500"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/responses/default"
       tags:
-      - gewijzigdepersonen
+      - Gewijzigde personen
 components:
+  parameters:
+    burgerservicenummer:
+      in: path
+      name: burgerservicenummer
+      required: true
+      description: "Identificerend gegeven van een ingeschreven natuurlijk persoon, als bedoeld in artikel 1.1 van de Wet\
+        \ algemene bepalingen burgerservicenummer."
+      schema:
+        pattern: "^[0-9]*$"
+        maxLength: 9
+        minLength: 9
+        example: "555555021"
   schemas:
-    VolgindicatiePersonenHalCollectie:
+    VolgindicatiesHalCollectie:
       type: object
       properties:
         _links:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalCollectionLinks"
         _embedded:
-          $ref: '#/components/schemas/VolgindicatiePersonen'
-    VolgindicatiePersonen:
+          $ref: '#/components/schemas/VolgindicatiesHal'
+    VolgindicatiesHal:
       type: object
       properties:
-        volgindicatiepersonen:
+        volgindicaties:
           type: array
           items:
-            $ref: '#/components/schemas/VolgindicatiePersoon'
-    VolgindicatiePersoon:
+            $ref: '#/components/schemas/VolgindicatieHal'
+    Volgindicatie:
       type: object
       properties:
-        burgerservicenummer:
-          $ref: '#/components/schemas/Burgerservicenummer'
-        deleteDatum:
+        einddatum:
           type: "string"
           format: "date"
-          description: "Datum vanaf wanneer de volgindicatie niet meer actief zal zijn en deze verwijderd wordt."
+          description: "Datum vanaf wanneer de volgindicatie niet meer actief zal zijn."
+    Volgindicatie_links:
+      type: object
+      properties:
+        self:
+          $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/schemas/HalLink'
+    VolgindicatieHal:
+      allOf:
+        - $ref: '#/components/schemas/Volgindicatie'
+        - properties:
+            _links:
+              $ref: '#/components/schemas/Volgindicatie_links'
+          example:
+            einddatum: '2022-10-24'
+            _links:
+              self:
+                href: '/volgindicaties/555555021'
     GewijzigdepersonenHalCollectie:
       type: object
       properties:
@@ -206,7 +270,10 @@ components:
         burgerservicenummers:
           type: array
           items:
-            $ref: '#/components/schemas/Burgerservicenummer'
+            type: "string"
+            description: "Identificerend gegeven van een ingeschreven natuurlijk persoon, als bedoeld in artikel 1.1 van de Wet\
+              \ algemene bepalingen burgerservicenummer."
+            example: "555555021"
     GewijzigdepersonenHalCollectionLinks:
       type: object
       properties:
@@ -214,15 +281,3 @@ components:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         ingeschrevenPersoon:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-    Burgerservicenummer:
-      type: "string"
-      title: "Burgerservicenummer"
-      description: "Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet\
-        \ algemene bepalingen burgerservicenummer. Alle nummers waarvoor geldt\
-        \ dat, indien aangeduid als (s0 s1 s2 s3 s4 s5 s6 s7 s8), het resultaat\
-        \ van (9*s0) + (8*s1) + (7*s2) +...+ (2*s7) - (1*s8) deelbaar is door\
-        \ elf. Er moeten dus 9 cijfers aanwezig zijn."
-      pattern: "^[0-9]*$"
-      maxLength: 9
-      minLength: 9
-      example: "555555021"

--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -5,8 +5,7 @@ servers:
     url: https://virtserver.swaggerhub.com/VNGRealisatie/api/brp_update_api
 info:
   title: "BRP Update API"
-  description: "Deze API biedt functionaliteit voor het opvragen van  wijzigingen op ingeschreven personen die door de gebruiker worden gevolgd vanaf een bepaald moment. Dit kan gebruikt worden om een kopie aan te leggen van de actuele registratie van specifieke personen.<br/>
-        De API biedt functionaliteit waarmee kan worden aangegeven welke personen worden gevolgd."
+  description: "Met deze API kun je opvragen welke door jou gevolgde personen zijn gewijzigd in de BRP. Je kunt je abonneren op een persoon die je wilt volgen, en je kunt opvragen welke personen door jou worden gevolgd. Je kunt deze API gebruiken in combinatie met de BRP bevragen API, bijvoorbeeld om lokale kopiegegevens actueel te houden."
   version: "1.0.0"
   contact:
     url: https://github.com/JohanBoer/Haal-Centraal-BRP-Update-API

--- a/api-specificatie/openapi.yaml
+++ b/api-specificatie/openapi.yaml
@@ -141,7 +141,7 @@ paths:
       operationId: DeleteVolgindicatie
       description: |
         Verwijderen van een volgindicatie van een specifieke persoon.
-      summary: "Toevoegen of wijzigen volgindicatie"
+      summary: "Verwijderen volgindicatie"
       parameters:
         - $ref: '#/components/parameters/burgerservicenummer'
       responses:


### PR DESCRIPTION
n.a.v. #20 en beslissingen die in overleg zijn genomen:

- POST vervangen door PUT die functioneert als upsert (insect of update)
- DELETE operatie weer toegevoegd
- burgerservicenummer verwijderd uit volgindicaties resource
- in response body zit burgerservicenummer in de self-link (resource identificatie)
- deleteDatum is weer einddatum geworden
- descriptions aangepast om werking te verduidelijken

Op een aantal plekken juiste responses (foutsituaties) toegevoegd of onjuiste verwijderd. Betreft opmerkingen op #17 die verloren zijn gegaan met #21.

Ook heb ik de endpoints gewijzigd van "volgindicatiepersonen" naar "volgindicaties". En "gewijzigdepersonen" naar "wijzigingen". Het is immers al duidelijk dat het over personen gaat, want het heet "BRP update API"

API is in Swagger formaat te raadplegen op https://petstore.swagger.io/?url=https://raw.githubusercontent.com/fsamwel/Haal-Centraal-BRP-Update-API/upsert/api-specificatie/openapi.yaml