### PR TITLE
Revert "Bump semver-regex from 3.1.3 to 3.1.4"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2599,9 +2599,9 @@
       "dev": true
     },
     "semver-regex": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
-      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
+      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
       "dev": true
     },
     "set-blocking": {


### PR DESCRIPTION
Reverts VNG-Realisatie/Haal-Centraal-BRP-Update-API#98