### PR TITLE
Revert "Bump urijs from 1.19.10 to 1.19.11"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2832,9 +2832,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
-      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "version": "1.19.10",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.10.tgz",
+      "integrity": "sha512-EzauQlgKuJgsXOqoMrCiePBf4At5jVqRhXykF3Wfb8ZsOBMxPcfiVBcsHXug4Aepb/ICm2PIgqAUGMelgdrWEg==",
       "dev": true
     },
     "util-deprecate": {


### PR DESCRIPTION
Reverts VNG-Realisatie/Haal-Centraal-BRP-Update-API#97